### PR TITLE
Bug fixes in EMC_maskReference and some other updates.

### DIFF
--- a/coordinates/EMC_coordTransform.m
+++ b/coordinates/EMC_coordTransform.m
@@ -123,13 +123,13 @@ if ~isempty(varargin)
         if ~isscalar(varargin{3}) && ~isnan(varargin{3})
             error('EMC:varargin', 'For a 2d case, vZ should be NaN')
         else
-            vX = EMC_setMethod(EMC_setPrecision(varargin{1}, OPTION.precision), METHOD);
-            vY = EMC_setMethod(EMC_setPrecision(varargin{2}, OPTION.precision), METHOD);
+            vX = EMC_setMethod(cast(varargin{1}, OPTION.precision), METHOD);
+            vY = EMC_setMethod(cast(varargin{2}, OPTION.precision), METHOD);
         end
     else
-        vX = EMC_setMethod(EMC_setPrecision(varargin{1}, OPTION.precision), METHOD);
-       	vY = EMC_setMethod(EMC_setPrecision(varargin{2}, OPTION.precision), METHOD);
-        vZ = EMC_setMethod(EMC_setPrecision(varargin{3}, OPTION.precision), METHOD);
+        vX = EMC_setMethod(cast(varargin{1}, OPTION.precision), METHOD);
+       	vY = EMC_setMethod(cast(varargin{2}, OPTION.precision), METHOD);
+        vZ = EMC_setMethod(cast(varargin{3}, OPTION.precision), METHOD);
     end
 
     if ~isnumeric(vX) || ~isrow(vX) || SIZE(1) ~= length(vX)
@@ -386,7 +386,7 @@ else
     OPTION.normalize = false;  % default
 end
 
-% precision is checked by EMC_coordVectors or EMC_setPrecision
+% precision is checked by EMC_coordVectors or cast
 if ~isfield(OPTION, 'precision')
     OPTION.precision = 'single';  % default
 end

--- a/coordinates/EMC_coordVectors.m
+++ b/coordinates/EMC_coordVectors.m
@@ -58,7 +58,7 @@ function [vX, vY, vZ] = EMC_coordVectors(SIZE, METHOD, OPTION)
 %   [~,y]   = EMC_coordVectors([1, 64], 'cpu', {'origin', -1; 'normalize',true});
 %
 % Other EMC-files required:
-%   EMC_is3d, EMC_getOption, EMC_setPrecision
+%   EMC_is3d, EMC_getOption
 %
 % See also EMC_is3d
 %
@@ -174,9 +174,9 @@ if OPTION.origin >= 0
     if isDim(1)
         if OPTION.half
             if OPTION.origin == 0 && ~mod(SIZE(1), 2)  % real center and even pixels
-                vX = 0.5:EMC_setPrecision((SIZE(1)/2), OPTION.precision);
+                vX = 0.5:cast((SIZE(1)/2), OPTION.precision);
             else
-                vX = 0:EMC_setPrecision(floor(SIZE(1)/2), OPTION.precision);
+                vX = 0:cast(floor(SIZE(1)/2), OPTION.precision);
             end
         else
             vX = (limits(1, 1) - OPTION.shift(1)):(limits(2, 1) - OPTION.shift(1));
@@ -192,7 +192,7 @@ if OPTION.origin >= 0
 else
     if isDim(1)
         if (OPTION.half)
-            vX = 0:EMC_setPrecision(floor(SIZE(1)/2), OPTION.precision);
+            vX = 0:cast(floor(SIZE(1)/2), OPTION.precision);
         else
             vX = [0:limits(2,1), limits(1,1):-1];
         end

--- a/masking/EMC_centerOfMass.m
+++ b/masking/EMC_centerOfMass.m
@@ -1,19 +1,19 @@
 function COM = EMC_centerOfMass(IMAGE, ORIGIN)
 %
-% COM = EMC_centerOfMass(IMAGE, ORIGIN)
+% COM = EMC_centerOfMass(IMAGE, MASK, ORIGIN)
 % Compute the center of mass of real space 2d/3d IMAGE.
 %
 % Input:
-%   IMAGE (numeric):	2d/3d IMAGE.
+%   IMAGE (numeric):    2d/3d image.
 %
-%   ORIGIN (int):     	Origin convention; 0, 1 or 2;
+%   ORIGIN (int):       Origin convention; 0, 1 or 2;
 %                       The center of mass (COM) is relative to this origin.
-%                      	See EMC_coordVectors for more details.
+%                       See EMC_coordVectors for more details.
 %
 % Output:
 %   COM (row vector):   Center of mass of the IMAGE; 2d:[x,y] or 3d:[x,y,z]
 %                       NOTE: it has the same precision and method as the IMAGE.
-%                             Use EMC_setPrecision|cast and EMC_setMethod to cast/push|gather.
+%                             Use cast and EMC_setMethod to cast/push|gather.
 %
 % Other EMC-files required:
 %   EMC_getClass, EMC_coordVectors

--- a/masking/EMC_maskIndex.m
+++ b/masking/EMC_maskIndex.m
@@ -5,17 +5,26 @@ function INDEX = EMC_maskIndex(TYPE, SIZE, METHOD, OPTION)
 %
 % Input:
 %   TYPE (str):             Type of wrapping available.
-%                           'fftshift':  Calculate the linear indices to go from a not-centered
-%                                        (zero first) to a centered spectrum.
+%                           'fftshift':     Calculate the linear indices to go from a not-centered
+%                                           (zero first) to a centered spectrum.
 %
-%                           'ifftshift': Calculate the linear indices to go from a centered
-%                                        to a not-centered (zero first) spectrum.
+%                           'ifftshift':    Calculate the linear indices to go from a centered
+%                                           to a not-centered (zero first) spectrum.
 %
-%                           'half2full': Calculate the linear indices to go from a half grid to
-%                                        full grid. This is for not-centered (zero first) grids.
-%                                        These indexes are meant to be applied on the full grid
-%                                        containing half of the spectrum.
-%                                        See EMC_irfftn for more details.
+%                           'nc2nc':        Calculate the linear indices to go from a half not-centered
+%                                           spectrum, to a full not-centered spectrum. These indexes are
+%                                           meant to be applied on the full grid containing half the
+%                                           spectrum in (1:floor(SIZE(1)/2)+1, :, :).
+%
+%                           'c2c':          Calculate the linear indices to go from a half centered
+%                                           spectrum, to a full centered spectrum. These indexes are
+%                                           meant to be applied on the full grid containing half the
+%                                           spectrum in (1:floor(SIZE(1)/2)+1, :, :).
+%
+%                           'c2nc':         Calculate the linear indices to go from a half centered
+%                                           spectrum, to a full not-centered spectrum. These indexes
+%                                           are meant to be applied on the full grid containing half
+%                                           the spectrum in (1:floor(SIZE(1)/2)+1, :, :).
 %
 %   SIZE (vector):          Size (in pixel) of the 3d/2d grid; [x, y, z] or [x, y].
 %                           NOTE: [1,1], [N,1] or [1,N] are not allowed.
@@ -28,10 +37,10 @@ function INDEX = EMC_maskIndex(TYPE, SIZE, METHOD, OPTION)
 %                           NOTE: Can be empty.
 %                           NOTE: Unknown fields will raise an error.
 %
-%     -> 'half' (bool):     Whether or not the output mask should correspond to the half (non-redondant)
-%                           grid. If true, the first dimension of the output will have floor(SIZE(1)/2)+1
-%                           pixels.
-%                           NOTE: It must be false if TYPE = 'half2full'.
+%     -> 'half' (bool):     Whether or not the output mask should correspond to the half (non-redundant)
+%                           spectrum. If true, the first dimension of the half mask is not shifted and
+%                           the first dimension of the half mask will be floor(SIZE(1)/2)+1.
+%                           NOTE: It must be false if TYPE = 'nc2nc' or 'c2c'.
 %                           default = false
 %
 %     -> 'precision' (str): Precision of the INDEX grid.
@@ -44,19 +53,36 @@ function INDEX = EMC_maskIndex(TYPE, SIZE, METHOD, OPTION)
 %                           NOTE: If OPTION.half=true, size(INDEX,1) == floor(SIZE(1)/2) + 1.
 %
 % Note:
-% - 2d: sub2ind(SIZE, gX, gY) <=> gX + (gY-1)*SIZE(1)
-%   3d: sub2ind(SIZE, gX, gY, gZ) <=> gX + (gY-1)*SIZE(1) + (gZ-1)*SIZE(1)*SIZE(2)
-%   This is already much faster than sub2ind and it can be further simplified using vectors.
-%   Moreover, it can be done directly with integers, whereas sub2ind requires floats.
+%   - 2d: sub2ind(SIZE, gX, gY) <=> gX + (gY-1)*SIZE(1)
+%     3d: sub2ind(SIZE, gX, gY, gZ) <=> gX + (gY-1)*SIZE(1) + (gZ-1)*SIZE(1)*SIZE(2)
+%     This is already much faster than sub2ind and it can be further simplified using vectors.
+%     Moreover, it can be done directly with integers, whereas sub2ind requires floats.
+%
+% Example:
+%   - the fftshift/ifftshift masks should be directly be applied to the spectrum you want to shift:
+%     >> dft = fftn(rand(128,128));                               % random spectrum
+%     >> dft_shift1 = fftshift(dft);                              % center the spectrum
+%     >> mask = EMC_maskIndex('fftshift', [128,128], 'cpu', {});  % create wrapping mask
+%     >> dft_shift2 = dft(mask);                                  % center the spectrum
+%     >> dft_shift1 == dft_shift2
+%
+%   - Compute the full (redundant) spectrum using the half (non-redundant) spectrum:
+%     >> dft_half = EMC_rfftn(rand(128,128));                  % half spectrum of size [65, 128]
+%     >> mask = EMC_maskIndex('nc2nc', [128,128], 'cpu', {});  % create wrapping mask
+%     >> dft_full = zeros(128,128);                            % allocate memory for the full spectrum
+%     >> dft_full(1:65,:) = dft_half;                          % put the half spectrum in the full spectrum
+%     >> dft_full = dft_full(mask);                            % apply wrapping to reconstruct full spectrum
 %
 % Other EMC-files required:
-%   EMC_is3d, EMC_getOption, EMC_setPrecision, EMC_setMethod
+%   EMC_is3d, EMC_getOption, EMC_setMethod
 %
 % See also fftshift, ifftshift, EMC_rfftn, EMC_irfftn
 %
 
 % Created:  15Feb2020, R2019a
 % Version:  v.1.0   Unittest (TF, 16Feb2020).
+%           v.1.1   Wrap for half to full spectrum is now supported (TYPE = 'c2c');
+%                   'half2full' is now 'nc2nc' (TF, 8Mar2020).
 %
 
 %% checkIN
@@ -112,15 +138,24 @@ else
 end
 
 %% Compute the indexes
-% half2full
-if strcmpi(TYPE, 'half2full')
+if strcmpi(TYPE, 'nc2nc') || strcmpi(TYPE, 'c2nc')
     cR = floor(SIZE/2) + 1;  % center receiver
     cD = ceil(SIZE/2);  % center donor
 
-    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);
+    SIZE = EMC_setMethod(cast(SIZE, OPTION.precision), METHOD);
     INDEX = reshape(1:prod(SIZE, 'native'), SIZE);  % linear indexes of a grid with desired size
 
     if is3d
+        % If half is centered, do ifftshift before.
+        if strcmpi(TYPE, 'c2nc')
+            tmp = INDEX(1:cR(1), 1:cD(2), 1:cD(3));
+            INDEX(1:cR(1), 1:cD(2), 1:cD(3)) = INDEX(1:cR(1), cD(2)+1:end, cD(3)+1:end);
+            INDEX(1:cR(1), cD(2)+1:end, cD(3)+1:end) = tmp;
+ 
+            tmp = INDEX(1:cR(1), 1:cD(2), cD(3)+1:end);
+            INDEX(1:cR(1), 1:cD(2), cD(3)+1:end) = INDEX(1:cR(1), cD(2)+1:end, 1:cD(3));
+            INDEX(1:cR(1), cD(2)+1:end, 1:cD(3)) = tmp;
+        end
         INDEX(cR(1)+1:end, 1,           1)           = INDEX(cD(1):-1:2, 1,              1);
         INDEX(cR(1)+1:end, 2:cR(2),     1)           = INDEX(cD(1):-1:2, end:-1:cD(2)+1, 1);
         INDEX(cR(1)+1:end, cR(2)+1:end, 1)           = INDEX(cD(1):-1:2, cD(2):-1:2,     1);
@@ -131,9 +166,53 @@ if strcmpi(TYPE, 'half2full')
         INDEX(cR(1)+1:end, cR(2)+1:end, 2:cR(3))     = INDEX(cD(1):-1:2, cD(2):-1:2,     end:-1:cD(3)+1);
         INDEX(cR(1)+1:end, cR(2)+1:end, cR(3)+1:end) = INDEX(cD(1):-1:2, cD(2):-1:2,     cD(3):-1:2);
     else  % 2d
+        % If half is centered, do ifftshift before.
+        if strcmpi(TYPE, 'c2nc')
+            tmp = INDEX(1:cR(1), 1:cD(2));
+            INDEX(1:cR(1), 1:cD(2)) = INDEX(1:cR(1), cD(2)+1:end);
+            INDEX(1:cR(1), cD(2)+1:end) = tmp;
+        end
         INDEX(cR(1)+1:end, 1)           = INDEX(cD(1):-1:2, 1);
         INDEX(cR(1)+1:end, 2:cR(2))     = INDEX(cD(1):-1:2, end:-1:cD(2)+1);
         INDEX(cR(1)+1:end, cR(2)+1:end) = INDEX(cD(1):-1:2, cD(2):-1:2);
+    end
+
+elseif strcmpi(TYPE, 'c2c')
+    c = floor(SIZE/2) + 1;  % center
+    e = 1 + ~mod(SIZE, 2);  % left edge
+
+    SIZE = EMC_setMethod(cast(SIZE, OPTION.precision), METHOD);
+    INDEX = reshape(1:prod(SIZE, 'native'), SIZE);  % linear indexes of a grid with desired size
+    if e(1) == 2  % X is even
+        extra = INDEX(c(1), :, :);  % save the extra line/plane
+    end
+
+    % Shift half to end of X, then flip the common chuck and then deal with
+    % extra line/plane for even dimensions.
+    if is3d
+        INDEX(c(1):end, :, :) = INDEX(1:ceil(SIZE(1)/2), :, :);
+        INDEX(e(1):c(1)-1, e(2):end, e(3):end) = INDEX(end:-1:c(1)+1, end:-1:e(2), end:-1:e(3));
+        if e(1) == 2  % X is even
+            INDEX(1, :, :) = extra;
+        end
+        if e(2) == 2  % Y is even
+            INDEX(e(1):c(1)-1, 1, e(3):end)   = INDEX(end:-1:c(1)+1, 1, end:-1:e(3));
+        end
+        if e(3) == 3  % Z is even
+            INDEX(e(1):c(1)-1, e(2):end, 1)   = INDEX(end:-1:c(1)+1, end:-1:e(2), 1);
+            if e(2) == 2  % Y and Z are both even
+                INDEX(e(1):c(1)-1, 1, 1)   = INDEX(end:-1:c(1)+1, 1, 1);
+            end
+        end
+    else  % 2d
+        INDEX(c(1):end, :) = INDEX(1:ceil(SIZE(1)/2), :);
+        INDEX(e(1):c(1)-1, e(2):end)  = INDEX(end:-1:c(1)+1, end:-1:e(2));
+        if e(1) == 2  % X is even
+            INDEX(1, :) = extra;
+        end
+        if e(2) == 2  % Y is even
+            INDEX(e(1):c(1)-1, 1) = INDEX(end:-1:c(1)+1, 1);
+        end
     end
 
 % fftshift and ifftshift
@@ -143,10 +222,10 @@ else
     elseif strcmpi(TYPE, 'ifftshift')
         half = floor(SIZE/2);
     else
-        error('EMC:TYPE', "TYPE should be 'fftshift', 'ifftshift' or 'half2full'")
+        error('EMC:TYPE', "TYPE should be 'fftshift', 'ifftshift', 'nc2nc', 'c2nc' or 'c2c'")
     end
 
-    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);  % convert after the division
+    SIZE = EMC_setMethod(cast(SIZE, OPTION.precision), METHOD);  % convert after the division
     if OPTION.half; vX = (1:SIZE(1))'; else; vX = [half(1)+1:SIZE(1), 1:half(1)]'; end
 
     % Concatenation appears to be faster than fftshift and circshift.

--- a/masking/EMC_resize.m
+++ b/masking/EMC_resize.m
@@ -68,7 +68,7 @@ function [OUT] = EMC_resize(IMAGE, LIMITS, OPTION)
 %   - [OUT] = EMC_resize(randn(64,64), [10,10,-5,0], {'value', 2; 'origin', -1})
 %
 % Other EMC-files required:
-%   EMC_setPrecision.m, EMC_getClass.m, EMC_is3d.m, EMC_getOption.m, EMC_isOnGpu, EMC_taper
+%   EMC_getClass.m, EMC_is3d.m, EMC_getOption.m, EMC_isOnGpu, EMC_taper
 %
 % See also EMC_limits.
 %
@@ -89,7 +89,7 @@ function [OUT] = EMC_resize(IMAGE, LIMITS, OPTION)
 
 % Short cut: nothing to do to the IMAGE, except maybe changing its precision.
 if ~flg.pad && ~flg.crop && ~(flg.taper && OPTION.force_taper)
-    OUT = EMC_setPrecision(IMAGE, OPTION.precision);
+    OUT = cast(IMAGE, OPTION.precision);
     return
 end
 
@@ -102,8 +102,8 @@ end
 
 % Option to pad with white gaussian noise.
 if flg.uniform
-    val = EMC_setPrecision(mean(IMAGE, 'all'), OPTION.precision);
-    std_ = EMC_setPrecision(std(IMAGE, 0, 'all'), OPTION.precision);
+    val = cast(mean(IMAGE, 'all'), OPTION.precision);
+    std_ = cast(std(IMAGE, 0, 'all'), OPTION.precision);
 else
     val = OPTION.value;
     std_ = nan;
@@ -156,7 +156,7 @@ if flg.is3d
             OUT(1:l(x),       end-r(y):end, end-r(z):end) = IMAGE(1:l(x),       end-r(y):end, end-r(z):end);
             OUT(end-r(x):end, end-r(y):end, end-r(z):end) = IMAGE(end-r(x):end, end-r(y):end, end-r(z):end);
         else
-            OUT = EMC_setPrecision(IMAGE, OPTION.precision);  % force_taper without pad or crop
+            OUT = cast(IMAGE, OPTION.precision);  % force_taper without pad or crop
         end
     else  % centered IMAGE: 'origin' = 0|1|2
         crop = abs(LIMITS .* (LIMITS < 0));
@@ -179,7 +179,7 @@ if flg.is3d
         elseif flg.crop
             OUT(:,:,:) = IMAGE(1+crop(1):end-crop(2), 1+crop(3):end-crop(4), 1+crop(5):end-crop(6));
         else
-            OUT = EMC_setPrecision(IMAGE, OPTION.precision);  % force_taper without pad or crop
+            OUT = cast(IMAGE, OPTION.precision);  % force_taper without pad or crop
         end
     end
 else  % 2d
@@ -198,7 +198,7 @@ else  % 2d
             OUT(1:l(x),       end-r(y):end) = IMAGE(1:l(x),       end-r(y):end);
             OUT(end-r(x):end, end-r(y):end) = IMAGE(end-r(x):end, end-r(y):end);
         else
-            OUT = EMC_setPrecision(IMAGE, OPTION.precision);  % force_taper without pad or crop
+            OUT = cast(IMAGE, OPTION.precision);  % force_taper without pad or crop
         end
     else  % centered IMAGE: 'origin' = 0|1|2
         crop = abs(LIMITS .* (LIMITS < 0));
@@ -217,7 +217,7 @@ else  % 2d
         elseif flg.crop
             OUT(:,:) = IMAGE(1+crop(1):end-crop(2), 1+crop(3):end-crop(4));
         else
-            OUT = EMC_setPrecision(IMAGE, OPTION.precision);  % force_taper without pad or crop
+            OUT = cast(IMAGE, OPTION.precision);  % force_taper without pad or crop
         end
     end
 end
@@ -404,11 +404,11 @@ if isfield(OPTION, 'value')
     if strcmpi(OPTION.value, 'uniform')
         flg.uniform = true;
     elseif strcmpi(OPTION.value, 'mean')
-        OPTION.value = EMC_setPrecision(mean(IMAGE, 'all'), OPTION.precision);
+        OPTION.value = cast(mean(IMAGE, 'all'), OPTION.precision);
         flg.uniform = false;
     elseif isnumeric(OPTION.value) && isscalar(OPTION.value)
         flg.uniform = false;
-        OPTION.value = EMC_setPrecision(OPTION.value, OPTION.precision);
+        OPTION.value = cast(OPTION.value, OPTION.precision);
         if ~flg.gpu && EMC_isOnGpu(OPTION.value)
             OPTION.value = gather(OPTION.value);
         end

--- a/masking/EMC_taper.m
+++ b/masking/EMC_taper.m
@@ -41,7 +41,7 @@ function [TAPER] = EMC_taper(TYPE, NUMEL, OPTION)
 %     OUT (single): [1, 0.8, 0.6, 0.4, 0.2, 0]
 %
 % Other EMC-files required:
-%   EMC_getOption, EMC_setMethod, EMC_setPrecision
+%   EMC_getOption, EMC_setMethod
 %
 
 % Created:  18Jan2020, R2019a
@@ -132,6 +132,6 @@ else
 end
 
 % Cast to desired precision; push or gather if necessary.
-TAPER = EMC_setMethod(EMC_setPrecision(TAPER, OPTION.precision), OPTION.method);
+TAPER = EMC_setMethod(cast(TAPER, OPTION.precision), OPTION.method);
 
 end

--- a/testScripts/EMC_convn.m
+++ b/testScripts/EMC_convn.m
@@ -27,8 +27,8 @@ function IMAGE = EMC_convn(IMAGE, KERNEL)
 % Example:
 %   - a = rand(1000,1000);
 %     % b and c are equal, up to the single/double precision accuracy.
-%     b = EMC_convn(a, EMC_gaussianKernel([5,5], 1, {}));  % classic kernel
-%     c = EMC_convn(a, EMC_gaussianKernel([1,5], 1, {}));  % separable kernel
+%     b = EMC_convn(a, EMC_gaussianKernel([5,5], 1, 'cpu', {}));  % classic kernel
+%     c = EMC_convn(a, EMC_gaussianKernel([1,5], 1, 'cpu', {}));  % separable kernel
 %
 % See also EMC_gaussianKernel
 %

--- a/testScripts/EMC_getOption.m
+++ b/testScripts/EMC_getOption.m
@@ -23,10 +23,14 @@ function OPTION = EMC_getOption(OPTION, ONLY, FILTER)
 % Created:  18Jan2020
 % Version:  v.1.0   unittest (TF, 20Jan2020).
 %           v.1.0.1 new error identifier convention (TF, 30Jan2020).
+%           v.1.0.2 clearer error message when the cell has not the correct size.
 %
 
 if iscell(OPTION)
     if ~isempty(OPTION)
+        if size(OPTION, 2) ~= 2
+            error('EMC:OPTION', 'OPTION should be a nx2 cell, got %s cell', mat2str(size(OPTION)))
+        end
         fields = OPTION(:, 1);
         OPTION = cell2struct(OPTION(:, 2), fields, 1);
         for idx = 1:numel(fields)

--- a/testScripts/EMC_irfftn.m
+++ b/testScripts/EMC_irfftn.m
@@ -51,7 +51,7 @@ end
 % h2f wrapper
 persistent wrap
 if isempty(wrap) || ~isequal(size(wrap), SIZE)
-    wrap = EMC_maskIndex('half2full', SIZE, method, {});
+    wrap = EMC_maskIndex('nc2nc', SIZE, method, {});
 end
 
 cR = floor(SIZE/2) + 1;  % center receiver

--- a/testScripts/EMC_test/EMC_runTest.m
+++ b/testScripts/EMC_test/EMC_runTest.m
@@ -147,7 +147,7 @@ for iTest = 1:nbTests
 
     try
         % Run test.
-        outputs = cell(1, nargout(testCase.TestData.functionToTest));
+        outputs = cell(1, abs(nargout(testCase.TestData.functionToTest)));
         [outputs{:}] = testCase.TestData.functionToTest(testCase.TestData.toTest{iTest, 1:end-2});
 
         if testCase.TestData.toTest{iTest, end-1}  % an error was expected but wasn't raised.

--- a/testScripts/EMC_test/test_EMC_convn.m
+++ b/testScripts/EMC_test/test_EMC_convn.m
@@ -46,9 +46,10 @@ end
 
 % separable
 if EXTRA && isvector(KERNEL)
-   	out = EMC_convn(IMAGE, EMC_gaussianKernel(zeros(1, ndims(IMAGE)) + length(KERNEL), EXTRA, ...
-                    {'precision', actualPrecision; 'method', actualMethod}));
-  	if any(abs(out - convolvedImg) > 1e-6, 'all')
+    kSize = zeros(1, ndims(IMAGE)) + length(KERNEL);
+   	out = EMC_convn(IMAGE, ...
+                    EMC_gaussianKernel(kSize, EXTRA, actualMethod, {'precision', actualPrecision}));
+  	if any(abs(out - convolvedImg) > 1e-5, 'all')
       	message = 'separable kernel does not give the same results as standard kernel';
        	return
     end
@@ -69,27 +70,27 @@ sizesKernel = {[5,5];[6,6];[1,5];[5,1];[1,6];[6,1]};
 % cpu double
 sizes = help_getRandomSizes(2, [10,300], '2d');
 img = help_getBatch({'fixtureRand'}, {'cpu'}, {'double'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'double';'method','cpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'cpu'}, {{'precision', 'double'}});
 testCase.TestData.toTest = help_getBatch(img, kernel, {false}, sigma);
 
 % cpu single
 sizes = help_getRandomSizes(2, [10,300], '2d');
 img = help_getBatch({'fixtureRand'}, {'cpu'}, {'single'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'single';'method','cpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'cpu'}, {{'precision', 'single'}});
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
                             help_getBatch(img, kernel, {false}, sigma)];
 
 % gpu double
 sizes = help_getRandomSizes(2, [10,300], '2d');
 img = help_getBatch({'fixtureRand'}, {'gpu'}, {'double'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'double';'method','gpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'gpu'}, {{'precision', 'double'}});
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
                             help_getBatch(img, kernel, {false}, sigma)];
 
 % cpu single
 sizes = help_getRandomSizes(2, [10,300], '2d');
 img = help_getBatch({'fixtureRand'}, {'gpu'}, {'single'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'single';'method','gpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'gpu'}, {{'precision', 'single'}});
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
                             help_getBatch(img, kernel, {false}, sigma)];
 
@@ -107,27 +108,27 @@ sizesKernel = {[5,5,5];[6,6,6];[1,5];[5,1];[1,6];[6,1]};
 % cpu double
 sizes = help_getRandomSizes(2, [10,300], '3d');
 img = help_getBatch({'fixtureRand'}, {'cpu'}, {'double'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'double';'method','cpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'cpu'}, {{'precision', 'double'}});
 testCase.TestData.toTest = help_getBatch(img, kernel, {false}, sigma);
 
 % cpu single
 sizes = help_getRandomSizes(2, [10,300], '3d');
 img = help_getBatch({'fixtureRand'}, {'cpu'}, {'single'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'single';'method','cpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'cpu'}, {{'precision', 'single'}});
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
                             help_getBatch(img, kernel, {false}, sigma)];
 
 % gpu double
 sizes = help_getRandomSizes(2, [10,300], '3d');
 img = help_getBatch({'fixtureRand'}, {'gpu'}, {'double'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'double';'method','gpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'gpu'}, {{'precision', 'double'}});
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
                             help_getBatch(img, kernel, {false}, sigma)];
 
 % cpu single
 sizes = help_getRandomSizes(2, [10,300], '3d');
 img = help_getBatch({'fixtureRand'}, {'gpu'}, {'single'}, sizes);
-kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {{'precision', 'single';'method','gpu'}});
+kernel = help_getBatch({'fixtureKernel'}, sizesKernel, sigma, {'gpu'}, {{'precision', 'single'}});
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
                             help_getBatch(img, kernel, {false}, sigma)];
 

--- a/testScripts/EMC_test/test_EMC_gaussianKernel.m
+++ b/testScripts/EMC_test/test_EMC_gaussianKernel.m
@@ -4,13 +4,13 @@ end
 
 
 function setupOnce(testCase)
-testCase.TestData.debug = 2;
+testCase.TestData.debug = 0;
 testCase.TestData.functionToTest = @EMC_gaussianKernel;
 testCase.TestData.evaluateOutput = @evaluateOutput;
 end
 
 
-function [result, message] = evaluateOutput(SIZE, ~, OPTION, OUTPUTCELL, ~)
+function [result, message] = evaluateOutput(SIZE, ~, METHOD, OPTION, OUTPUTCELL, ~)
 % [KERNEL] = EMC_gaussianKernel(SIZE, SIGMA, OPTION)
 % Check:
 %   METHOD:     output has the expected method
@@ -37,14 +37,9 @@ if iscell(OPTION) && ~isempty(OPTION) && any(strcmp(OPTION(:, 1), 'precision'))
 else
     expectedPrecision = 'single';  % default
 end
-if iscell(OPTION) && ~isempty(OPTION) && any(strcmp(OPTION(:, 1), 'method'))
-    expectedMethod = OPTION{strcmp(OPTION(:, 1), 'method'), 2};
-else
-    expectedMethod = 'cpu';  % default
-end
 
-if ~strcmp(actualMethod, expectedMethod)
-   	message = sprintf('expected output method = %s, got %s', actualMethod, expectedMethod);
+if ~strcmpi(actualMethod, METHOD)
+   	message = sprintf('expected output method = %s, got %s', actualMethod, METHOD);
     return
 elseif ~strcmp(actualPrecision, expectedPrecision)
    	message = sprintf('expected output precision = %s, got %s', actualPrecision, expectedPrecision);
@@ -71,17 +66,17 @@ end
 function test_default(testCase)
 % 2d
 sizes = help_getRandomSizes(5, [3, 20], '2d');
+method = {'cpu'; 'gpu'};
 sigmas = [help_getRandomSizes(2, [1,5], '2d'); help_getRandomSizes(2, [1,5], '1d')];
-option = help_getBatchOption({'precision', {'single'; 'double'}; ...
-                              'method', {'cpu'; 'gpu'}});
+option = help_getBatchOption({'precision', {'single'; 'double'}});
 
-testCase.TestData.toTest = help_getBatch(sizes, sigmas, option, {false}, {false});
+testCase.TestData.toTest = help_getBatch(sizes, sigmas, method, option, {false}, {false});
 
 % 3d
 sizes = help_getRandomSizes(2, [3, 20], '3d');
 sigmas = [help_getRandomSizes(2, [1,5], '3d'); help_getRandomSizes(2, [1,5], '1d')];
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
-                            help_getBatch(sizes, sigmas, option, {false}, {false})];
+                            help_getBatch(sizes, sigmas, method, option, {false}, {false})];
 
 EMC_runTest(testCase);
 end
@@ -90,19 +85,22 @@ end
 function test_assumption(testCase)
 % sizes
 sizes = {[5,5,5,5]; 5; 'kayak'; []; {}; nan; inf; [nan, nan]; [inf; inf]; [1,1,1]; [1,1]};
-testCase.TestData.toTest = help_getBatch(sizes, {1}, {{}}, {'EMC:SIZE'}, {false});
+testCase.TestData.toTest = help_getBatch(sizes, {1}, {'cpu'}, {{}}, {'EMC:SIZE'}, {false});
 
 % sigmas
 sigmas = {[1,1,1]; 'kayak'; nan; inf; {}; -2; 0; [nan;1]};
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
-                            help_getBatch({[10,10]}, sigmas, {{}}, {'EMC:SIGMA'}, {false}); ...
-                            {[10,10,10], [10,10], {}, 'EMC:SIGMA', false}];
+                            help_getBatch({[10,10]}, sigmas, {'cpu'}, {{}}, {'EMC:SIGMA'}, {false}); ...
+                            {[10,10,10], [10,10], 'cpu', {}, 'EMC:SIGMA', false}];
+
+% method
+methods = {''; 'doubles'; 12; []; nan; inf};
+testCase.TestData.toTest = help_getBatch({[10,10]}, {1}, methods, {{}}, {'EMC:METHOD'}, {false});
 
 % options
-options = help_getBatchOption({'precision', {''; 'doubles'; 12; []; nan; inf}; ...
-                               'method', {''; 'doubles'; 12; []; nan; inf}});
+options = help_getBatchOption({'precision', {''; 'doubles'; 12; []; nan; inf}});
 options = options(~cellfun(@isempty, options), :);
 testCase.TestData.toTest = [testCase.TestData.toTest; ...
-                            help_getBatch({[10,10]}, {1}, options, {'error'}, {false})];
+                            help_getBatch({[10,10]}, {1}, {'cpu'}, options, {'error'}, {false})];
 EMC_runTest(testCase);
 end

--- a/testScripts/EMC_test/test_EMC_maskIndex.m
+++ b/testScripts/EMC_test/test_EMC_maskIndex.m
@@ -13,7 +13,7 @@ function [result, message] = evaluateOutput(TYPE, SIZE, METHOD, OPTION, OUTPUTCE
 % check the size, method and precision
 % if TYPE='fftshift', compare shift with fftshift
 % if TYPE='ifftshift', compare shift with ifftshift
-% if TYPE='half2full', compare with ifftn (same test as EMC_irfftn)
+% if TYPE='nc2nc', compare with ifftn (same test as EMC_irfftn)
 
 % if half SIZE, use the half2full option to recompute the full grid,
 % then compare with fftshift or ifftshift.
@@ -117,7 +117,7 @@ elseif strcmpi(TYPE, 'ifftshift')
     end
 end
 
-% half2full is tested in test_EMC_rfftn_and_irfftn
+% nc2nc is tested in test_EMC_rfftn_and_irfftn
 
 % You have passed the test, congratulation.
 result = 'passed';
@@ -127,7 +127,7 @@ end
 
 
 function test_default(testCase)
-types = {'fftshift'; 'ifftshift'; 'half2full'; "fftshift"; "ifftshift"; "half2full"};
+types = {'fftshift'; 'ifftshift'; 'nc2nc'; "fftshift"; "ifftshift"; "nc2nc"};
 sizes = [help_getRandomSizes(5, [500, 2000], '2d'); help_getRandomSizes(5, [50, 200], '3d')];
 methods = {'cpu'; 'gpu'};
 options = help_getBatchOption({'half', {true; false}; ...

--- a/testScripts/EMC_test/test_EMC_maskReference.m
+++ b/testScripts/EMC_test/test_EMC_maskReference.m
@@ -1,0 +1,162 @@
+function tests = test_EMC_maskReference
+tests = functiontests(localfunctions);
+end
+
+
+function setupOnce(testCase)
+testCase.TestData.debug = 2;
+testCase.TestData.functionToTest = @p_EMC_maskReference;
+testCase.TestData.evaluateOutput = @evaluateOutput;
+testCase.TestData.fixture_Rand = @help_getInputRand;
+
+global EMC_gp_verbose
+EMC_gp_verbose = false;
+end
+
+
+function [o1, o2, o3, o4] = p_EMC_maskReference(IMAGE, PIXEL, OPTION)
+
+if help_isOptionDefined(OPTION, 'fsc') && help_getOptionParam(OPTION, 'fsc')
+    [o1, o2, o3, o4] = EMC_maskReference(IMAGE, PIXEL, OPTION);
+else
+    [o1, o2] = EMC_maskReference(IMAGE, PIXEL, OPTION);
+    o3 = 'empty';
+    o4 = 'empty';
+end
+
+end
+
+
+function [result, message] = evaluateOutput(IMAGE, ~, OPTION, OUTPUTCELL, ~)
+% [MASK, COM]                      = EMC_maskReference(IMAGE, PIXEL, OPTION) if 'fsc'=false.
+% [MASK, MASK_CORE, FRACTION, COM] = EMC_maskReference(IMAGE, PIXEL, OPTION) if 'fsc'=true.
+%
+% Check:
+%   METHOD:     MASK, MASK_CORE, COM are following the METHOD instruction.
+%   PRECISION:  MASK, MASK_CORE, COM have the desired precision
+%   SIZE:       MASK, MASK_CORE, COM, FRACTION have the correct size.
+%
+%   If EXTRA, load and check for equality with fixture.
+%
+
+result = 'failed';
+
+if help_isOptionDefined(OPTION, 'fsc') && help_getOptionParam(OPTION, 'fsc')
+    isFsc = true;
+else
+    isFsc = false;
+end
+
+% method and precision
+[expectedMethod, expectedPrecision] = help_getClass(IMAGE);
+
+% MASK - precision, method and size
+[method, precision] = help_getClass(OUTPUTCELL{1});
+if ~strcmpi(method, expectedMethod)
+    message = sprintf('MASK, expected method=%s, got %s', expectedMethod, method);
+    return
+elseif ~strcmpi(precision, expectedPrecision)
+    message = sprintf('MASK, expected precision=%s, got %s', expectedPrecision, precision);
+    return
+elseif ~isequal(size(IMAGE), size(OUTPUTCELL{1}))
+    message = sprintf('MASK, expected size=%s, got %s',mat2str(size(IMAGE)), mat2str(size(OUTPUTCELL{1})));
+    return
+end
+
+if isFsc
+    % MASK_CORE - precision, method and size
+    [method, precision] = help_getClass(OUTPUTCELL{2});
+    if ~strcmp(method, expectedMethod)
+        message = sprintf('MASK_CORE, expected method=%s, got %s', expectedMethod, method);
+        return
+    elseif ~strcmp(precision, expectedPrecision)
+        message = sprintf('MASK_CORE, expected precision=%s, got %s', expectedPrecision, precision);
+        return
+    elseif ~isequal(size(IMAGE), size(OUTPUTCELL{2}))
+        message = sprintf('MASK_CORE, expected size=%s, got %s', mat2str(size(IMAGE)), mat2str(size(OUTPUTCELL{2})));
+        return
+    end
+    
+    % FRACTION
+    if ~isnumeric(OUTPUTCELL{3}) || ~isscalar(OUTPUTCELL{3}) || isinf(OUTPUTCELL{3}) || isnan(OUTPUTCELL{3})
+        message = sprintf('FRACTION should be a numeric scalar, not inf and not nan');
+        return
+    end
+    
+    % COM - precision, method and size
+    if help_isOptionDefined(OPTION, 'com') && help_getOptionParam(OPTION, 'com')
+        [method, precision] = help_getClass(OUTPUTCELL{4});
+        if ~strcmp(method, expectedMethod)
+            message = sprintf('COM, expected method=%s, got %s', expectedMethod, method);
+            return
+        elseif ~strcmp(precision, expectedPrecision)
+            message = sprintf('COM, expected precision=%s, got %s', expectedPrecision, precision);
+            return
+        elseif ~isequal(size(size(IMAGE)), size(OUTPUTCELL{4}))
+            message = sprintf('COM, expected size=%s, got %s', mat2str(size(size(IMAGE))), mat2str(size(OUTPUTCELL{4})));
+            return
+        end
+    else
+        if ~isscalar(OUTPUTCELL{4}) || ~isnan(OUTPUTCELL{4})
+            message = sprintf('COM should be nan');
+            return
+        end
+    end
+else
+    % COM - precision, method and size
+    if help_isOptionDefined(OPTION, 'com') && help_getOptionParam(OPTION, 'com')
+        [method, precision] = help_getClass(OUTPUTCELL{2});
+        if ~strcmp(method, expectedMethod)
+            message = sprintf('COM, expected method=%s, got %s', expectedMethod, method);
+            return
+        elseif ~strcmp(precision, expectedPrecision)
+            message = sprintf('COM, expected precision=%s, got %s', expectedPrecision, precision);
+            return
+        elseif ~isequal(size(size(IMAGE)), size(OUTPUTCELL{2}))
+            message = sprintf('COM, expected size=%s, got %s', mat2str(size(size(IMAGE))), mat2str(size(OUTPUTCELL{2})));
+            return
+        end
+    else
+        if ~isscalar(OUTPUTCELL{2}) || ~isnan(OUTPUTCELL{2})
+            message = sprintf('COM should be nan');
+            return
+        end
+    end
+end
+
+% You have passed the test, congratulation.
+result = 'passed';
+message = '';
+
+end
+
+
+function test_default(testCase)
+% Test for 2d/3d, cpu/gpu and every option.
+%
+
+sizes = [help_getRandomSizes(1, [50, 100], '2d'); help_getRandomSizes(1, [50, 100], '3d')];
+precisions = {'single'; 'double'};
+methods = {'cpu'; 'gpu'};
+imgs = help_getBatch({'fixture_Rand'}, methods, precisions, sizes);
+
+pixel = {1};
+
+option = help_getBatchOption({'precision', {'single' ; 'double'}; ...
+                              'method', {'cpu'; 'gpu'}; ...
+                              'com', {true; false}; ...
+                              'fsc', {true; false}; ...
+                              });
+option = [option; ...
+          help_getBatchOption({'origin', {0; 1; 2}; ...
+                               'hydration_scaling', {2.5}; ...
+                               'lowpass', {20}; ...
+                               'threshold', {3}; ...
+                               'com', {true}; ...
+                               'fsc', {true}; ...
+                               })];
+
+testCase.TestData.toTest = help_getBatch(imgs, pixel, option, {false}, {false});
+EMC_runTest(testCase);
+
+end

--- a/testScripts/EMC_test/test_EMC_maskShape.m
+++ b/testScripts/EMC_test/test_EMC_maskShape.m
@@ -72,15 +72,15 @@ function test_default_2d(testCase)
 
 shapes = {'rectangle'; 'sphere'; 'cylinder'};
 sizes = help_getRandomSizes(1, [50, 1000], '2d');
-radius = help_getRandomSizes(1, [10, 400], '2d');
+radius = [help_getRandomSizes(1, [10, 400], '2d'); [30.5,32.1]];
 method = {'cpu'; 'gpu'};
 
 kernel = [1.5e-06 0.00013 0.0044 0.054 0.24 0.4 0.24 0.054 0.0044 0.00013 1.5e-06];
 option = help_getBatchOption({'origin', {1; 2}; ...
                               'precision', {'single' ; 'double'}; ...
-                              'sym', {1;2;3;6}; ...
+                              'sym', {1;2;6}; ...
                               'kernel', {true;false;0;0.2;kernel}; ...
-                              'shift', help_getRandomSizes(1, [-100,100], '2d')});
+                              'shift', [help_getRandomSizes(1, [-100,100], '2d'); [30.5,-32.1]]});
 
 testCase.TestData.toTest = help_getBatch(shapes, sizes, radius, method, option, {false}, {false});
 EMC_runTest(testCase);
@@ -94,15 +94,15 @@ function test_default_3d(testCase)
 
 shapes = {'rectangle'; 'sphere'; 'cylinder'};
 sizes = help_getRandomSizes(1, [50, 200], '3d');
-radius = help_getRandomSizes(1, [10, 100], '3d');
+radius = [help_getRandomSizes(1, [10, 100], '3d'); [30.5,32.1,20.4]];
 method = {'cpu'; 'gpu'};
 
 kernel = [1.5e-06 0.00013 0.0044 0.054 0.24 0.4 0.24 0.054 0.0044 0.00013 1.5e-06];
 option = help_getBatchOption({'origin', {1; 2}; ...
                               'precision', {'single' ; 'double'}; ...
-                              'sym', {1;2;3;6}; ...
+                              'sym', {1;2;6}; ...
                               'kernel', {true;false;0;0.2;kernel}; ...
-                              'shift', help_getRandomSizes(1, [-100,100], '3d')});
+                              'shift', [help_getRandomSizes(1, [-100,100], '3d'); [-30.5,32.1,-20.4]]});
 
 testCase.TestData.toTest = help_getBatch(shapes, sizes, radius, method, option, {false}, {false});
 EMC_runTest(testCase);

--- a/transformations/@EMC_Fourier/EMC_Fourier.m
+++ b/transformations/@EMC_Fourier/EMC_Fourier.m
@@ -1,0 +1,190 @@
+classdef EMC_Fourier < handle
+% Fourier transformer for EMC functions.
+% This class supports half (non-redundant) and
+% full (redundant) Discrete Fourier Transforms (DFT).
+%
+
+% Created: 8Mar2020, R2019a
+% Version: v.1.0
+%
+
+    % These attributes cannot be changed from outside the class methods.
+    properties (SetAccess = private)
+        size_real 	% size of the real space image
+        size_freq  	% size of the frequency space spectrum.
+        method    	% 'gpu' or 'cpu'
+        precision 	% 'single' or 'double'
+        is3d
+        isEven
+        isOnGpu
+        centered  	% change frequency order of the spectrums, bandpass and indexes.
+        half      	% compute half transforms, bandpass and indexes.
+        half_wrap
+
+        % These are used by the getters to know if the indexes are already set.
+        index_fftshift_isSet = false;
+      	index_ifftshift_isSet = false;
+        index_half2full_isSet = false;
+    end
+
+    % These attributes cannot be changed from outside the class methods.
+    % These attributes depends on the others attributes defined above.
+    properties (Dependent = true, SetAccess = private)
+        bandpass
+        index_fftshift
+        index_ifftshift
+        index_half2full
+    end
+
+    % Constructor
+    methods
+        function obj = EMC_Fourier(SIZE, METHOD, OPTION)
+        %
+        % obj = EMC_Fourier(SIZE, METHOD, OPTION)
+        % Constructor of EMC_Fourier.
+        %
+        % Input:
+        %   SIZE (vector):              Size (in pixel) of the 3d/2d grids to transform; [x, y, z] or [x, y].
+        %                               NOTE: [1,1], [N,1] or [1,N] are not allowed.
+        %                               NOTE: This cannot be changed after initialization.
+        %
+        %	METHOD (str):               Method to use; 'gpu' or 'cpu'.
+        %                               NOTE: This can be changed after initialization using to().
+        %
+        %   OPTION (cell|struct):       Optional parameters.
+        %                               If cell: {field,value ; ...}, note the ';' between parameters.
+        %                               NOTE: Can be empty.
+        %                               NOTE: Unknown fields will raise an error.
+        %
+        %	  -> 'precision' (str):     Precision of the transforms; 'single' or 'double'.
+        %                               NOTE: This can be changed after initialization using to().
+        %                               default = 'single'
+        %
+        %     -> 'half' (bool):         Wheter or not the transformer should compute (and expect) the
+        %                               non-redundant spectrum/bandpass. 
+        %                               NOTE: This cannot be changed after initialization.
+        %                               default = true
+        %
+        %     -> 'centered' (bool): 	Wheter or not the spectrums/bandpass should be centered (fftshift).
+        %                               This will automatically fftshift the transforms after fft and
+        %                               ifftshift the transforms before ifft.
+        %                               NOTE: This cannot be changed after initialization.
+        %                               default = false
+        %
+        %     -> 'plans' (str):         'estimate', 'measure', 'patient', 'exhaustive', 'hybrid' or 'none'
+        %                               Create the fftw plans; equivalent to fftw('planned', plans).
+        %                               default = 'none'
+        %
+        % Output:
+        %   obj (handle):               Instance of the EMC_Fourier class.
+        %
+        % Other EMC-files required:
+        %   EMC_is3d, EMC_getOption
+        %
+
+        [obj.is3d, obj.size_real] = EMC_is3d(SIZE);
+        obj.isEven = ~mod(obj.size_real, 2);
+
+        % method
+        if strcmpi(METHOD, 'gpu')
+            obj.method = 'gpu';
+            obj.isOnGpu = true;
+        elseif strcmpi(METHOD, 'cpu')
+            obj.method = 'cpu';
+            obj.isOnGpu = false;
+        else
+            error('EMC:Fourier', "METHOD should be 'gpu' or 'cpu'")
+        end
+
+        OPTION = EMC_getOption(OPTION, {'precision', 'mode_half', 'mode_fftshift', 'plans'}, false);
+
+        % precision
+        if isfield(OPTION, 'precision')
+            if ~(ischar(OPTION.precision) || isstring(OPTION.precision)) || ...
+               ~strcmpi(OPTION.precision, 'single') && ~strcmpi(OPTION.precision, 'double')
+                error('EMC:Fourier', "OPTION.precision should be 'single' or 'double'")
+            end
+            obj.precision = OPTION.precision;
+        else
+            obj.precision = 'single';  % default
+        end
+
+        % centered
+        if isfield(OPTION, 'centered')
+            if ~isscalar(OPTION.centered) && ~islogical(OPTION.centered)
+                error('EMC:Fourier', 'OPTION.centered should be true or false')
+            end
+            obj.centered = OPTION.centered;
+        else
+            obj.centered = true;  % default
+        end
+
+        % half
+        if isfield(OPTION, 'half')
+            if ~isscalar(OPTION.half) && ~islogical(OPTION.half)
+                error('EMC:Fourier', 'OPTION.half should be true or false')
+            end
+            obj.half = OPTION.half;
+            if obj.half
+                obj.size_freq = [floor(SIZE(1) / 2) + 1, SIZE(2:end)];
+                if obj.centered; obj.half_wrap = 'c2nc'; else; obj.half_wrap = 'nc2nc'; end
+            else
+                obj.size_freq = obj.size_real;
+            end
+        else
+            obj.half = true;  % default
+            obj.size_freq = [floor(SIZE(1) / 2) + 1, SIZE(2:end)];
+            obj.half_wrap = 'nc2nc';
+        end
+
+        % plans
+        if ~isfield(OPTION, 'plans') || strcmpi(OPTION.plans, 'none')
+            OPTION.plans = 'none';  % default
+        else
+            fftw('planned', OPTION.plans)
+            fftn(zeros(obj.size_real));
+        end
+
+        end  % EMC_Fourier
+    end
+
+    methods (Access = public)
+        DFT = fft(obj, IMAGE);
+        IMAGE = ifft(obj, DFT);
+        obj = setBandpass(obj, ARRAY, PIXEL, HIGHPASS, LOWPASS, OPTION);
+        ARRAY = applyBandpass(obj, ARRAY, OPTION);
+        obj = to(obj, STR);
+    end
+ 	methods (Static)
+        INDEX = getIndex(TYPE, SIZE, METHOD, OPTION);
+        FULL = half2full(WRAP, HALF, SIZE);
+    end
+
+    % Setters
+    methods
+        function value = get.index_fftshift(obj)
+            if ~obj.index_fftshift_isSet
+                obj.index_fftshift_isSet = true;
+                obj.index_fftshift = obj.getIndex('fftshift', obj.size_real, obj.method, ...
+                                                  {'half', obj.half});
+            end
+            value = obj.index_fftshift;
+        end
+        function value = get.index_ifftshift(obj)
+            if ~obj.index_ifftshift_isSet
+                obj.index_ifftshift_isSet = true;
+                obj.index_ifftshift = obj.getIndex('ifftshift', obj.size_real, obj.method, ...
+                                                   {'half', obj.half});
+            end
+            value = obj.index_ifftshift;
+        end
+        function value = get.index_half2full(obj)
+            if ~obj.index_half2full_isSet
+                obj.index_half2full_isSet = true;
+                obj.index_half2full = obj.getIndex(obj.half_wrap, obj.size_real, obj.method, ...
+                                                  {'half', obj.half});
+            end
+            value = obj.index_half2full;
+        end
+    end
+end

--- a/transformations/@EMC_Fourier/applyBandpass.m
+++ b/transformations/@EMC_Fourier/applyBandpass.m
@@ -1,0 +1,105 @@
+function ARRAY = applyBandpass(obj, ARRAY, OPTION)
+%
+% ARRAY = obj.applyBandpass(ARRAY, OPTION)
+% Apply the current bandpass filter (obj.bandpass) to an ARRAY.
+%
+% Input:
+%   ARRAY (numeric):           	2d/3d array to filter.
+%
+%   OPTION (cell|struct):       Optional parameters.
+%                              	If cell: {field, value; ...}, note the ';' between parameters.
+%                              	NOTE: Can be empty.
+%                             	NOTE: Unknown fields will raise an error.
+%
+%     -> 'fft' (bool):          Wheter or not the ARRAY is in real space.
+%                               If true:  compute the fft of ARRAY before applying the bandpass.
+%                               If false: apply the bandpass directly to the ARRAY. The size of the
+%                                         ARRAY should match the size of obj.bandpass.
+%                               default = true
+%
+%     -> 'ifft' (bool):         Wheter or not the ARRAY should be switched back to real space after
+%                               applying the bandpass. If false, the ARRAY is left in frequency space.
+%                              	default = true
+%
+%     -> 'standardize' (bool):  Set the real space mean to ~0 and real space variance to ~1 of the ARRAY.
+%                             	NOTE: the mean and variance are changed in frequency space.
+%                             	default = true
+%
+% Output:
+%   ARRAY (numeric):            Filtered ARRAY.
+%
+% Property used:
+%   obj.bandpass
+%
+% Method used:
+%   obj.fft
+%   obj.ifft
+%   obj.standardize
+%
+% Examples:
+%   - >> ft = EMC_Fourier([3740,3838], 'gpu', {});
+%     >> ft = ft.setBandpass(3, nan, 8, {});  % lowpass filter with cutoff at 8A
+%     >> img = ft.applyBandpass(img, {});
+%
+% Other EMC-files required:
+%   EMC_getOption
+%
+% See also obj.setBandpass.
+%
+
+% Created:  18Jan2020, R2019a
+% Version:  v.1.0.  symplify the inputs - use EMC_resize directly if you want to apply
+%                   a taper and/or pad|crop before applying the bandpass (TF, 2Feb2020).
+%           v.1.1.  explicit checks for IMAGE and BANDPASS; unittest (TF, 3Feb2020).
+%           v.1.2.  half bandpass are now supported (TF, 8Feb2020).
+%           v.1.2.1 bug fix: standardization with half grid is now properly done. (TF, 22Feb2020).
+%           v.1.3.  EMC_applyBandpass is integrated into EMC_Fourier.applyBandpass; can now used
+%                   ARRAYs already in Fourier space (OPTION.fft) (TF, 8Mar2020).
+%
+
+%% checkIN
+OPTION = EMC_getOption(OPTION, {'fft', 'ifft', 'standardize'}, false);
+
+% isfreq
+if isfield(OPTION, 'fft')
+    if ~islogical(OPTION.fft) && ~isscalar(OPTION.fft)
+        error('EMC:Fourier', 'OPTION.fft should be a boolean')
+    end
+else
+    OPTION.fft = true;  % default
+end
+
+% ifft
+if isfield(OPTION, 'ifft')
+    if ~islogical(OPTION.ifft) && ~isscalar(OPTION.ifft)
+        error('EMC:Fourier', 'OPTION.ifft should be a boolean')
+    end
+else
+    OPTION.ifft = true;  % default
+end
+
+% standardize
+if isfield(OPTION, 'standardize')
+    if ~islogical(OPTION.standardize) && ~isscalar(OPTION.standardize)
+        error('EMC:Fourier', 'OPTION.standardize should be a boolean')
+    end
+else
+    OPTION.standardize = true;  % default
+end
+
+%% Apply filter.
+if OPTION.fft
+    ARRAY = obj.fft(ARRAY) .* obj.bandpass;
+else
+    ARRAY = ARRAY .* obj.bandpass;
+end
+
+if OPTION.standardize
+    ARRAY = obj.standardize(ARRAY);
+end
+
+if OPTION.ifft
+    ARRAY = obj.ifft(ARRAY);
+end
+
+end  % applyBandpass

--- a/transformations/@EMC_Fourier/fft.m
+++ b/transformations/@EMC_Fourier/fft.m
@@ -1,0 +1,43 @@
+function DFT = fft(obj, IMAGE)
+%
+% DFT = obj.fft(IMAGE)
+% N-D Fast Fourier Transform of a real 2d/3d IMAGE.
+%
+% Input:
+%   IMAGE (numeric):    2d or 3d numerical array (real).
+%
+% Output:
+%   DFT (numeric):      Half or full discrete Fourier transform of IMAGE (complex).
+%
+% Property used:
+%   obj.half
+%   obj.centered
+%   obj.size_freq
+%   obj.index_fftshift
+%
+% Example:
+%   - >> ft = EMC_Fourier([128,128,128], 'gpu', {});
+%     >> img = rand(128,128,128);
+%     >> dft = ft.fft(img);
+%
+
+% Created:  3Feb2020
+% Version:  v.1.0.  unittest (TF, 8Feb2020).
+%           v.1.1.  EMC_rfftn is integrated into EMC_Fourier.fft; can return
+%                   half/full not-centered/centered DFTs (TF, 8Mar2020).
+%
+
+% This is a real pain that MATLAB doesn't support this by default.
+DFT = fftn(IMAGE);
+
+% Return only non-redundant spectrum.
+if obj.half
+    DFT = DFT(1:obj.size_freq(1), :, :);
+end
+
+% Shift the zero frequency to the center of the spectrum.
+if obj.centered
+    DFT = DFT(obj.index_fftshift);
+end
+
+end  % fft

--- a/transformations/@EMC_Fourier/fftshift.m
+++ b/transformations/@EMC_Fourier/fftshift.m
@@ -1,0 +1,125 @@
+function DFT = fftshift(DFT)
+%
+% DFT = fftshift(DFT)
+% Shift zero-frequency component to the center of spectrum.
+%
+% Created:  15Feb2020, R2019a
+% Version:  v.1.0   Unittest (TF, 16Feb2020).
+%
+
+%% checkIN
+[is3d, SIZE] = EMC_is3d(SIZE);
+if any(SIZE == 1)
+    error('EMC:SIZE', 'SIZE should corresponding to a 2d or 3d array, got %s', mat2str(SIZE))
+end
+
+OPTION = EMC_getOption(OPTION, {'half', 'precision'}, false);
+
+% half
+if isfield(OPTION, 'half')
+    if ~islogical(OPTION.half) || ~isscalar(OPTION.half)
+        error('EMC:half', 'OPTION.half should be a boolean, got %s', class(OPTION.half));
+    elseif OPTION.half
+        SIZE(1) = floor(SIZE(1)/2) + 1;  % switch to corresponding half size
+    end
+else
+    OPTION.half = false;  % default
+end
+
+% precision
+if isfield(OPTION, 'precision')
+    if (ischar(OPTION.precision) || isstring(OPTION.precision))
+        if strcmpi(OPTION.precision, 'int')
+            if prod(SIZE) <= 2^16
+                OPTION.precision = 'int16';
+            elseif prod(SIZE) <= 2^32
+                OPTION.precision = 'int32';
+            else
+                OPTION.precision = 'int64';
+            end
+        elseif strcmpi(OPTION.precision, 'uint')
+            if prod(SIZE) <= 2^16
+                OPTION.precision = 'uint16';
+            elseif prod(SIZE) <= 2^32
+                OPTION.precision = 'uint32';
+            else
+                OPTION.precision = 'uint64';
+            end
+        elseif ~strcmpi(OPTION.precision, 'single') && ~strcmpi(OPTION.precision, 'double')
+            error('EMC:precision', "OPTION.precision should be 'single', 'double', 'int' or 'uint', got %s", OPTION.precision)
+        end
+    else
+      	error('EMC:precision', "OPTION.precision should be a string|char vector, got %s", class(OPTION.precision))
+    end
+elseif prod(SIZE) <= 2^16
+    OPTION.precision = 'uint16';  % default
+elseif prod(SIZE) <= 2^32
+    OPTION.precision = 'uint32';  % default
+else
+    OPTION.precision = 'uint64';  % default
+end
+
+%% Compute the indexes
+if strcmpi(TYPE, 'nc2nc')
+    cR = floor(SIZE/2) + 1;  % center receiver
+    cD = ceil(SIZE/2);  % center donor
+
+    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);
+    INDEX = reshape(1:prod(SIZE, 'native'), SIZE);  % linear indexes of a grid with desired size
+
+    if is3d
+        INDEX(cR(1)+1:end, 1,           1)           = INDEX(cD(1):-1:2, 1,              1);
+        INDEX(cR(1)+1:end, 2:cR(2),     1)           = INDEX(cD(1):-1:2, end:-1:cD(2)+1, 1);
+        INDEX(cR(1)+1:end, cR(2)+1:end, 1)           = INDEX(cD(1):-1:2, cD(2):-1:2,     1);
+        INDEX(cR(1)+1:end, 1,           2:cR(3))     = INDEX(cD(1):-1:2, 1,              end:-1:cD(3)+1);
+        INDEX(cR(1)+1:end, 1,           cR(3)+1:end) = INDEX(cD(1):-1:2, 1,              cD(3):-1:2);
+        INDEX(cR(1)+1:end, 2:cR(2),     2:cR(3))     = INDEX(cD(1):-1:2, end:-1:cD(2)+1, end:-1:cD(3)+1);
+        INDEX(cR(1)+1:end, 2:cR(2),     cR(3)+1:end) = INDEX(cD(1):-1:2, end:-1:cD(2)+1, cD(3):-1:2);
+        INDEX(cR(1)+1:end, cR(2)+1:end, 2:cR(3))     = INDEX(cD(1):-1:2, cD(2):-1:2,     end:-1:cD(3)+1);
+        INDEX(cR(1)+1:end, cR(2)+1:end, cR(3)+1:end) = INDEX(cD(1):-1:2, cD(2):-1:2,     cD(3):-1:2);
+    else  % 2d
+        INDEX(cR(1)+1:end, 1)           = INDEX(cD(1):-1:2, 1);
+        INDEX(cR(1)+1:end, 2:cR(2))     = INDEX(cD(1):-1:2, end:-1:cD(2)+1);
+        INDEX(cR(1)+1:end, cR(2)+1:end) = INDEX(cD(1):-1:2, cD(2):-1:2);
+    end
+
+elseif strcmpi(TYPE, 'c2c')
+    cD = floor(SIZE/2) + 1;  % center donor
+    cR = cD;  % center receiver
+    if mod(SIZE(1),2); isEven = 1; else; isEven = 0; end 
+
+    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);
+    INDEX = reshape(1:prod(SIZE, 'native'), SIZE);  % linear indexes of a grid with desired size
+
+    if is3d
+        
+        
+    else
+        INDEX(cR(1):end, :) = INDEX(1:cD(1)-isEven, :);
+        INDEX(1:cR(1)-1, 1:cR(2)-1) = INDEX(cD(1)+1:-1:2, cD(2):end);
+        INDEX(1:cR(1)-1, cR(2):end) = INDEX(cD(1)+1:-1:2, 1:cD(2)-1);
+    end
+
+% fftshift and ifftshift
+else
+    if strcmpi(TYPE, 'fftshift')
+        half = ceil(SIZE/2);
+    elseif strcmpi(TYPE, 'ifftshift')
+        half = floor(SIZE/2);
+    else
+        error('EMC:TYPE', "TYPE should be 'fftshift', 'ifftshift' or 'half2full'")
+    end
+
+    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);  % convert after the division
+    if OPTION.half; vX = (1:SIZE(1))'; else; vX = [half(1)+1:SIZE(1), 1:half(1)]'; end
+
+    % Concatenation appears to be faster than fftshift and circshift.
+    if is3d
+        INDEX = vX + [half(2):SIZE(2)-1, 0:half(2)-1] * SIZE(1) + ...
+                     reshape([half(3):SIZE(3)-1, 0:half(3)-1],1,1,[]) * (SIZE(1) * SIZE(2));
+    else
+        INDEX = vX + [half(2):SIZE(2)-1, 0:half(2)-1] * SIZE(1);
+    end
+end
+
+end  % EMC_coordIndex

--- a/transformations/@EMC_Fourier/getIndex.m
+++ b/transformations/@EMC_Fourier/getIndex.m
@@ -1,0 +1,235 @@
+function INDEX = getIndex(TYPE, SIZE, METHOD, OPTION)
+%
+% INDEX = EMC_Fourier.getIndex(TYPE, SIZE, METHOD, OPTION)
+% Compute linear indexes for different TYPE of wrapping.
+%
+% Input:
+%   TYPE (str):             Type of wrapping available.
+%                           'fftshift':     Calculate the linear indices to go from a not-centered
+%                                           (zero first) to a centered spectrum.
+%
+%                           'ifftshift':	Calculate the linear indices to go from a centered
+%                                           to a not-centered (zero first) spectrum.
+%
+%                           'nc2nc':        Calculate the linear indices to go from a half not-centered
+%                                           spectrum, to a full not-centered spectrum. These indexes are
+%                                           meant to be applied on the full grid containing half the
+%                                           spectrum in (1:floor(SIZE(1)/2)+1, :, :).
+%
+%                           'c2c':          Calculate the linear indices to go from a half centered
+%                                           spectrum, to a full centered spectrum. These indexes are
+%                                           meant to be applied on the full grid containing half the
+%                                           spectrum in (1:floor(SIZE(1)/2)+1, :, :).
+%
+%                           'c2nc':         Calculate the linear indices to go from a half centered
+%                                           spectrum, to a full not-centered spectrum. These indexes
+%                                           are meant to be applied on the full grid containing half
+%                                           the spectrum in (1:floor(SIZE(1)/2)+1, :, :).
+%
+%   SIZE (vector):          Size (in pixel) of the 3d/2d grid; [x, y, z] or [x, y].
+%                           NOTE: [1,1], [N,1] or [1,N] are not allowed.
+%                           NOTE: It must correspond to the full grid size even if OPTION.half = true.
+%
+%   METHOD (str):           Method used to compute the INDEX grid; 'cpu' or 'gpu'.
+%
+%   OPTION (cell|struct):   Optional parameters.
+%                           If cell: {field,value ; ...}, note the ';' between parameters.
+%                           NOTE: Can be empty.
+%                           NOTE: Unknown fields will raise an error.
+%
+%     -> 'half' (bool):     Whether or not the output mask should correspond to the half (non-redundant)
+%                           spectrum. If true, the first dimension of the half mask is not shifted and
+%                           the first dimension of the half mask will be floor(SIZE(1)/2)+1.
+%                           NOTE: It must be false if TYPE = 'nc2nc', 'c2nc' or 'c2c'.
+%                           default = false
+%
+%     -> 'precision' (str): Precision of the INDEX grid.
+%                           float: 'single' or 'double'.
+%                           integer: 'int', 'uint'.
+%                           default = 'uint' (select the most appropriate unassigned integer)
+%
+% Output:
+%   INDEX (numeric):        Linear indexes.
+%                           NOTE: If OPTION.half=true, size(INDEX,1) == floor(SIZE(1)/2) + 1.
+%
+% Note:
+%   - 2d: sub2ind(SIZE, gX, gY) <=> gX + (gY-1)*SIZE(1)
+%     3d: sub2ind(SIZE, gX, gY, gZ) <=> gX + (gY-1)*SIZE(1) + (gZ-1)*SIZE(1)*SIZE(2)
+%     This is already much faster than sub2ind and it can be further simplified using vectors.
+%     Moreover, it can be done directly with integers, whereas sub2ind requires floats.
+%
+% Example:
+%   - the fftshift/ifftshift masks should be directly be applied to the spectrum you want to shift:
+%     >> dft = fftn(rand(128,128));
+%     >> wrap = EMC_Fourier.getIndex('fftshift', [128,128], 'cpu', {});
+%     >> dft_centered = dft(wrap);  % equivalent to fftshift(dft)
+%
+%   - Compute the full (redundant) spectrum using the half (non-redundant) spectrum:
+%     See EMC_Fourier.half2full.
+%
+%
+% Other EMC-files required:
+%   EMC_is3d, EMC_getOption, EMC_setPrecision, EMC_setMethod
+%
+% See also fftshift, ifftshift, EMC_rfftn, EMC_irfftn
+%
+
+% Created:  15Feb2020, R2019a
+% Version:  v.1.0.  Unittest (TF, 16Feb2020).
+%           v.1.1.  EMC_maskIndex is integrated into EMC_Fourier.getIndex; added
+%                   the wrap 'c2nc' and 'c2c'; 'half2full' is now 'nc2nc' (TF, 8Mar2020).
+%
+
+%% checkIN
+[is3d, SIZE] = EMC_is3d(SIZE);
+if any(SIZE == 1)
+    error('EMC:SIZE', 'SIZE should corresponding to a 2d or 3d array, got %s', mat2str(SIZE))
+end
+
+OPTION = EMC_getOption(OPTION, {'half', 'precision'}, false);
+
+% half
+if isfield(OPTION, 'half')
+    if ~islogical(OPTION.half) || ~isscalar(OPTION.half)
+        error('EMC:half', 'OPTION.half should be a boolean, got %s', class(OPTION.half));
+    elseif OPTION.half
+        SIZE(1) = floor(SIZE(1)/2) + 1;  % switch to corresponding half size
+    end
+else
+    OPTION.half = false;  % default
+end
+
+% precision
+if isfield(OPTION, 'precision')
+    if (ischar(OPTION.precision) || isstring(OPTION.precision))
+        if strcmpi(OPTION.precision, 'int')
+            if prod(SIZE) <= 2^16
+                OPTION.precision = 'int16';
+            elseif prod(SIZE) <= 2^32
+                OPTION.precision = 'int32';
+            else
+                OPTION.precision = 'int64';
+            end
+        elseif strcmpi(OPTION.precision, 'uint')
+            if prod(SIZE) <= 2^16
+                OPTION.precision = 'uint16';
+            elseif prod(SIZE) <= 2^32
+                OPTION.precision = 'uint32';
+            else
+                OPTION.precision = 'uint64';
+            end
+        elseif ~strcmpi(OPTION.precision, 'single') && ~strcmpi(OPTION.precision, 'double')
+            error('EMC:precision', "OPTION.precision should be 'single', 'double', 'int' or 'uint', got %s", OPTION.precision)
+        end
+    else
+      	error('EMC:precision', "OPTION.precision should be a string|char vector, got %s", class(OPTION.precision))
+    end
+elseif prod(SIZE) <= 2^16
+    OPTION.precision = 'uint16';  % default
+elseif prod(SIZE) <= 2^32
+    OPTION.precision = 'uint32';  % default
+else
+    OPTION.precision = 'uint64';  % default
+end
+
+%% Compute the indexes
+if strcmpi(TYPE, 'nc2nc') || strcmpi(TYPE, 'c2nc')
+    cR = floor(SIZE/2) + 1;  % center receiver
+    cD = ceil(SIZE/2);  % center donor
+
+    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);
+    INDEX = reshape(1:prod(SIZE, 'native'), SIZE);  % linear indexes of a grid with desired size
+
+    if is3d
+        % If half is centered, do ifftshift before.
+        if strcmpi(TYPE, 'c2nc')
+            tmp = INDEX(1:cR(1), 1:cD(2), 1:cD(3));
+            INDEX(1:cR(1), 1:cD(2), 1:cD(3)) = INDEX(1:cR(1), cD(2)+1:end, cD(3)+1:end);
+            INDEX(1:cR(1), cD(2)+1:end, cD(3)+1:end) = tmp;
+            
+            tmp = INDEX(1:cR(1), 1:cD(2), cD(3)+1:end);
+            INDEX(1:cR(1), 1:cD(2), cD(3)+1:end) = INDEX(1:cR(1), cD(2)+1:end, 1:cD(3));
+            INDEX(1:cR(1), cD(2)+1:end, 1:cD(3)) = tmp;
+        end
+        INDEX(cR(1)+1:end, 1,           1)           = INDEX(cD(1):-1:2, 1,              1);
+        INDEX(cR(1)+1:end, 2:cR(2),     1)           = INDEX(cD(1):-1:2, end:-1:cD(2)+1, 1);
+        INDEX(cR(1)+1:end, cR(2)+1:end, 1)           = INDEX(cD(1):-1:2, cD(2):-1:2,     1);
+        INDEX(cR(1)+1:end, 1,           2:cR(3))     = INDEX(cD(1):-1:2, 1,              end:-1:cD(3)+1);
+        INDEX(cR(1)+1:end, 1,           cR(3)+1:end) = INDEX(cD(1):-1:2, 1,              cD(3):-1:2);
+        INDEX(cR(1)+1:end, 2:cR(2),     2:cR(3))     = INDEX(cD(1):-1:2, end:-1:cD(2)+1, end:-1:cD(3)+1);
+        INDEX(cR(1)+1:end, 2:cR(2),     cR(3)+1:end) = INDEX(cD(1):-1:2, end:-1:cD(2)+1, cD(3):-1:2);
+        INDEX(cR(1)+1:end, cR(2)+1:end, 2:cR(3))     = INDEX(cD(1):-1:2, cD(2):-1:2,     end:-1:cD(3)+1);
+        INDEX(cR(1)+1:end, cR(2)+1:end, cR(3)+1:end) = INDEX(cD(1):-1:2, cD(2):-1:2,     cD(3):-1:2);
+    else  % 2d
+        % If half is centered, do ifftshift before.
+        if strcmpi(TYPE, 'c2nc')
+            tmp = INDEX(1:cR(1), 1:cD(2));
+            INDEX(1:cR(1), 1:cD(2)) = INDEX(1:cR(1), cD(2)+1:end);
+            INDEX(1:cR(1), cD(2)+1:end) = tmp;
+        end
+        INDEX(cR(1)+1:end, 1)           = INDEX(cD(1):-1:2, 1);
+        INDEX(cR(1)+1:end, 2:cR(2))     = INDEX(cD(1):-1:2, end:-1:cD(2)+1);
+        INDEX(cR(1)+1:end, cR(2)+1:end) = INDEX(cD(1):-1:2, cD(2):-1:2);
+    end
+
+elseif strcmpi(TYPE, 'c2c')
+    c = floor(SIZE/2) + 1;  % center
+    e = 1 + ~mod(SIZE, 2);  % left edge
+
+    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);
+    INDEX = reshape(1:prod(SIZE, 'native'), SIZE);  % linear indexes of a grid with desired size
+    if e(1) == 2  % X is even
+        extra = INDEX(c(1), :, :);  % save the extra line/plane
+    end
+
+    % Shift half to end of X, then flip the common chuck and then deal with
+    % extra line/plane for even dimensions.
+    if is3d
+        INDEX(c(1):end, :, :) = INDEX(1:ceil(SIZE(1)/2), :, :);
+        INDEX(e(1):c(1)-1, e(2):end, e(3):end) = INDEX(end:-1:c(1)+1, end:-1:e(2), end:-1:e(3));
+        if e(1) == 2  % X is even
+            INDEX(1, :, :) = extra;
+        end
+        if e(2) == 2  % Y is even
+            INDEX(e(1):c(1)-1, 1, e(3):end)   = INDEX(end:-1:c(1)+1, 1, end:-1:e(3));
+        end
+        if e(3) == 3  % Z is even
+            INDEX(e(1):c(1)-1, e(2):end, 1)   = INDEX(end:-1:c(1)+1, end:-1:e(2), 1);
+            if e(2) == 2  % Y and Z are both even
+                INDEX(e(1):c(1)-1, 1, 1)   = INDEX(end:-1:c(1)+1, 1, 1);
+            end
+        end
+    else  % 2d
+        INDEX(c(1):end, :) = INDEX(1:ceil(SIZE(1)/2), :);
+        INDEX(e(1):c(1)-1, e(2):end)  = INDEX(end:-1:c(1)+1, end:-1:e(2));
+        if e(1) == 2  % X is even
+            INDEX(1, :) = extra;
+        end
+        if e(2) == 2  % Y is even
+            INDEX(e(1):c(1)-1, 1) = INDEX(end:-1:c(1)+1, 1);
+        end
+    end
+
+% fftshift and ifftshift
+else
+    if strcmpi(TYPE, 'fftshift')
+        half = ceil(SIZE/2);
+    elseif strcmpi(TYPE, 'ifftshift')
+        half = floor(SIZE/2);
+    else
+        error('EMC:TYPE', "TYPE should be 'fftshift', 'ifftshift', 'nc2nc', 'c2nc' or 'c2c'")
+    end
+
+    SIZE = EMC_setMethod(EMC_setPrecision(SIZE, OPTION.precision), METHOD);  % convert after the division
+    if OPTION.half; vX = (1:SIZE(1))'; else; vX = [half(1)+1:SIZE(1), 1:half(1)]'; end
+
+    % Concatenation appears to be faster than fftshift and circshift.
+    if is3d
+        INDEX = vX + [half(2):SIZE(2)-1, 0:half(2)-1] * SIZE(1) + ...
+                     reshape([half(3):SIZE(3)-1, 0:half(3)-1],1,1,[]) * (SIZE(1) * SIZE(2));
+    else
+        INDEX = vX + [half(2):SIZE(2)-1, 0:half(2)-1] * SIZE(1);
+    end
+end
+
+end  % EMC_Fourier.getIndex

--- a/transformations/@EMC_Fourier/half2full.m
+++ b/transformations/@EMC_Fourier/half2full.m
@@ -1,0 +1,83 @@
+function FULL = half2full(WRAP, HALF, SIZE, varargin)
+%
+% FULL = EMC_Fourier.half2full(WRAP, HALF, SIZE, varargin)
+% Applied the Hermitian symetry to the HALF spectrum to reconstruct the FULL spectrum.
+%
+% Input:
+%   WRAP (str|char):        Type of wrapping (always half -> full).
+%                           'nc2nc': Calculate the linear indices to go from a half
+%                                    non-centered spectrum to a full non-centered spectrum.
+%                           'c2nc':  Calculate the linear indices to go from a half centered
+%                                    spectrum to a full non-centered spectrum.
+%                           'c2c':   Calculate the linear indices to go from a half centered
+%                                    spectrum to a full centered spectrum.
+%
+%   HALF (numeric):         Half spectrum of size floor(SIZE/2)+1.
+%                           NOTE: if real (not complex), the Hermitian symetry becomes a central symetry.
+%
+%   SIZE (vector):          Size (in pixel) of the full spectrum; [x, y, z] or [x, y].
+%                           NOTE: [1,1], [N,1] or [1,N] are not allowed.
+%
+%   (optional)
+%   varargin{1} (numeric):  Use this wrapper to reconstruct the full grid.
+%                         	Its size and method should correspond to SIZE
+%                         	and method of HALF, respectively.
+%
+% Output:
+%   FULL (numeric):     Full spectrum of size obj.size_real.
+%                       Method and precision are unchanged.
+%
+% Example:
+%   - Compute the full (redundant) spectrum using the half (non-redundant) spectrum:
+%     >> ft = EMC_Fourier([128,128], 'cpu', {});
+%     >> dft_half = ft.fft(rand(128,128,'single'));
+%     >> dft_full = EMC_Fourier.half2full('nc2nc', dft_half, [128,128]);
+%
+% Other EMC-files required:
+%   EMC_is3d, EMC_getClass, EMC_shareMethod, EMC_Fourier.getIndex
+%
+
+% Created: 8Mar2020, R2019a
+% Version: 1.0.
+%
+
+[~, SIZE] = EMC_is3d(SIZE);
+[precision, isOnGpu, method] = EMC_getClass(HALF);
+if isOnGpu
+    FULL = zeros(SIZE, precision, 'gpuArray');
+else
+    FULL = zeros(SIZE, precision);
+end
+
+oX = floor(size(SIZE,1)/2)+1;
+
+% Every wrapper is expecting the half grid in this position.
+FULL(1:oX+1, :, :) = HALF;
+
+if nargin == 4
+    INDEX = varargin{1};
+    if ~isequal(size(INDEX), SIZE) || ~EMC_shareMethod(INDEX, HALF)
+        error('EMC:Fourier', 'INDEX should have correspond to SIZE and have the same method as HALF')
+    end
+else
+    INDEX = EMC_Fourier.getIndex(WRAP, SIZE, method, {});
+end
+
+FULL = FULL(INDEX);  % wrap
+
+% If complex, apply conjugate
+if ~isreal(HALF)
+    if strcmpi(WRAP, 'nc2nc') || strcmpi(WRAP, 'c2nc')
+        FULL(oX(1)+1:end, :, :) = conj(FULL(oX(1)+1:end, :, :));
+    elseif strcmpi(WRAP, 'c2c')  % half centered -> full centered
+        if ~mod(SIZE(1),2)
+            FULL(2:oX(1), :, :) = conj(FULL(2:oX(1), :, :));
+        else
+            FULL(1:oX(1), :, :) = conj(FULL(1:oX(1), :, :));
+        end
+    else
+        error('EMC:Fourier', "WRAP should be 'n2c', 'c2nc' or 'c2c'")
+    end
+end
+
+end  % half2full

--- a/transformations/@EMC_Fourier/ifft.m
+++ b/transformations/@EMC_Fourier/ifft.m
@@ -1,0 +1,50 @@
+function IMAGE = ifft(obj, DFT)
+%
+% IMAGE = obj.ifft(DFT)
+% N-D inverse Fast Fourier Transform wrapper, used for 2d/3d DFT of real images.
+%
+% Input:
+%   DFT (numeric):      2d or 3d Discrete Fourier Transform (complex).
+%
+% Output:
+%   IMAGE (numeric):    Inverse Discrete Fourier Transform of DFT (real).
+%
+% Property used:
+%   obj.half
+%   obj.half_wrap
+%   obj.size_real
+%   obj.centered
+%   obj.index_ifftshift
+%   obj.index_half2full
+%
+% Method used:
+%   EMC_Fourier.half2full
+%
+% Note:
+%   - Recomputing the full DFT has a non negligeable overload. This is only worth it
+%     if a lot of operation is done on the half grid whether than the full grid.
+%
+% Example:
+%   - >> ft = EMC_Fourier([128,128,128], 'gpu', {});
+%     >> img = rand(128,128,128);
+%     >> dft = ft.fft(img);
+%     >> img_back = ft.ifft(dft);  % img_back == img
+%
+
+% Created:  3Feb2020
+% Version:  v.1.0.  unittest (TF, 8Feb2020).
+%           v.1.1.  use EMC_maskIndex and a persistent wrapper to speed up
+%                   Fourier coefficients wrapping (half to full grid) (TF, 14Feb2020).
+%           v.1.2.  EMC_irfftn is integrated into EMC_Fourier.ifft; can used
+%                   half/full not-centered/centered DFTs (TF, 8Mar2020).
+%
+
+if obj.half
+    IMAGE  = ifftn(EMC_Fourier.half2full(obj.half_wrap, DFT, obj.size_real, obj.index_half2full), 'symmetric');
+elseif obj.centered
+    IMAGE  = ifftn(DFT(obj.index_ifftshift), 'symmetric');
+else
+    IMAGE  = ifftn(DFT, 'symmetric');
+end
+
+end  % ifft

--- a/transformations/@EMC_Fourier/ifftshift.m
+++ b/transformations/@EMC_Fourier/ifftshift.m
@@ -1,0 +1,4 @@
+function DFT = ifftshift(DFT)
+
+
+end

--- a/transformations/@EMC_Fourier/setBandpass.m
+++ b/transformations/@EMC_Fourier/setBandpass.m
@@ -1,0 +1,268 @@
+function obj = setBandpass(obj, PIXEL, HIGHPASS, LOWPASS, OPTION)
+%
+% obj = obj.setBandpass(PIXEL, HIGHPASS, LOWPASS, OPTION)
+% Create a 2D/3D filter; either a lowpass, highpass or bandpass filter.
+%
+% Input:
+%   PIXEL (float):                      Pixel size in A/pix.
+%
+%   HIGHPASS (float|nan):               Cutoff, in Angstrom, of the high pass filter.
+%                                       This cutoff corresponds to resolution where the pass is
+%                                       fully recovered. Must be higher (lower frequency) than LOWPASS.
+%                                       If nan or 0, the filter will be a low pass filter.
+%
+%   LOWPASS (float|str|nan):            Cutoff, in Angstrom, of the low pass filter.
+%                                       This cutoff corresponds to resolution where the pass starts
+%                                      	to roll off. Must be lower (higher frequency) than HIGHPASS.
+%                                       If nan or 0, the filter will be a high pass filter.
+%                                       If 'nyquist', starts the roll off at the Nyquist frequency.
+%                                       NOTE: should be higher (lower resolution) or equal to the
+%                                             Nyquist frequency.
+%
+%   OPTION (cell|struct):               Optional parameters.
+%                                       If cell: {field, value; ...}, note the ';' between parameters.
+%                                       NOTE: Can be empty.
+%                                       NOTE: Unknown fields will raise an error.
+%
+%     -> 'highpassRoll' (float|str):	Standard deviation of the HIGHPASS gaussian roll.
+%                                       If 'extended': extend the gaussian roll from the zero frequency
+%                                                      to HIGHPASS.
+%                                       NOTE: This is ignored if there is no HIGHPASS filter.
+%                                       NOTE: The radial grids used to compute the gaussian are normalized
+%                                             between [0,0.5]. The sigma should correspond to this range.
+%                                       default = 0.02
+%
+%     -> 'highpassThresh'(float):   	Sets the strength of the zero frequency, between 0 and 1.
+%                                       NOTE: This is ignored if there is no HIGHPASS filter and if
+%                                             'highpassRoll' is not equal to 'extended'.
+%                                       NOTE: If 0, the Gaussian will go to Inf, therefore the roll off
+%                                             becomes smaller than one pixel, which is equivalent to
+%                                             highpassRoll = 0.
+%                                       default = 1e-3
+%
+%     -> 'lowpassRoll' (float|str):     Standard deviation of the LOWPASS gaussian roll.
+%                                       If 'extended': extend the gaussian roll from the LOWPASS cutoff
+%                                                      to Nyquist.
+%                                       If LOWPASS is at Nyquist, the default gaussian roll is used anyway.
+%                                       NOTE: This is ignored if there is no LOWPASS filter.
+%                                       NOTE: The radial grids used to compute the gaussian are normalized
+%                                             between [0,0.5]. The sigma should correspond to this range.
+%                                       default = 0.02
+%
+%     -> 'lowpassThresh'(float):        Sets the strength of the Nyquist frequency, between 0 and 1.
+%                                       NOTE: This is ignored if there is no LOWPASS filter and if
+%                                             'lowpassRoll' is not equal to 'extended'.
+%                                       NOTE: If 0, the Gaussian will go to Inf, therefore the roll off
+%                                             becomes smaller than one pixel, which is equivalent to
+%                                             lowpassRoll = 0.
+%                                       default = 1e-3
+%
+% Output:
+%   Bandpass (numeric):                 Bandpass filter.
+%                                       If obj.half, the bandpass is non-redundant.
+%                                       If obj.centered, the banpass is centered.
+%
+% Note:
+%   - The default gaussian std (lowroll and highroll) of 0.02 and window (lowthresh and highthresh)
+%     of 0.001 gives a roll off large enough to 'remove' the Gibbs Phenomenon (ringing effect).
+%     These filters are far from perfect filter. One improvement to reduce unwanted frequency,
+%     could be to shift the cutoffs at ~0.8 or ~0.7 and not at 1 as they are currently.
+%
+%   - The size of the gaussian roll is relative to the size of the filter. It might cause an issue
+%     if the filter is very small (<100pixel wide) where the roll off is only over a few pixels.
+%     The current solution is to increase the low|high roll. One other solution could be to make
+%     sure the taper is at least ~10pixels.
+%
+% Example:
+%   - >> ft = EMC_Fourier([3740,3838], 'gpu', {});
+%     >> ft = ft.setBandpass(3, nan, 8, {});  % lowpass filter with cutoff at 8A
+%     >> img = ft.applyBandpass(img, {});
+%
+% Other EMC-files required:
+%   EMC_getOption, EMC_coordVectors
+%
+% See also EMC_Fourier.applyBandpass.
+%
+
+% Created:  18Jan2020, R2019a
+% Version:  v.1.0.  unittest (TF, 2Feb2020).
+%           v.1.0.1 LOWPASS can be 0, which is now equivalent to NaN (no lowpass filter).
+%                   If no highpass and no lowpass, compute a full pass (TF, 17Feb2020).
+%           v.1.1.  EMC_getBandpass is integrated into EMC_Fourier.setBandpass (TF, 8Mar2020).
+%
+
+%% checkIN
+defaultSigma = 0.02;
+[OPTION, flg] = checkIN(PIXEL, HIGHPASS, LOWPASS, OPTION, defaultSigma);
+
+% If no lowpass and no highpass, return ones.
+if ~flg.lowpass && ~flg.highpass
+    if obj.isOnGpu
+        obj.bandpass = ones(obj.size_freq, obj.precision, 'gpuArray');
+    else
+        obj.bandpass = ones(obj.size_freq, obj.precision);
+    end
+    return
+end
+
+if obj.centered; origin = -1; else; origin = 1; end
+[vX, vY, vZ] = EMC_coordVectors(obj.size_freq, obj.method, {'origin', origin; ...
+                                                            'half', obj.half; ...
+                                                            'normalize', true; ...
+                                                            'precision', obj.precision});
+
+% The radial grid is the same for both highpass and lowpass filters.
+if obj.is3d
+    radius = sqrt(vX'.^2 + vY.^2 + reshape(vZ,1,1,[]).^2);
+else
+    radius = sqrt(vX'.^2 + vY.^2);
+end
+
+% Normal gaussian
+gaussian = @(x,m,s) exp(-1.*(x-m).^2 ./ (2.*s.^2));
+
+%% High pass filter
+if flg.highpass
+    highpassCut = PIXEL / HIGHPASS;  % [1/pix]
+
+    % Gaussian roll
+    if strcmpi(OPTION.highpassRoll, 'extended')  % roll, up to the zero frequency
+        sigma = sqrt(-1 * highpassCut^2 / (2 * log(OPTION.highpassThresh)));
+        % Make sure the extended roll off is larger than default.
+        if sigma < defaultSigma
+            sigma = defaultSigma;
+        end
+    else  % classic gaussian roll
+        sigma = OPTION.highpassRoll;
+    end
+
+    obj.bandpass = (radius > highpassCut) + (radius <= highpassCut) .* gaussian(radius, highpassCut, sigma);
+end
+
+%% Lowpass filter
+if flg.lowpass
+    if strcmpi(LOWPASS, 'nyquist')
+        lowpassCut = 0.5;
+    else
+        lowpassCut = PIXEL / LOWPASS;  % [1/pix]
+    end
+    
+    % Gaussian roll
+    if strcmpi(OPTION.lowpassRoll, 'extended')  % roll, up to nyquist
+        sigma = sqrt(-1 * ((0.5 - lowpassCut).^2) / (2 * log(OPTION.lowpassThresh)));
+        % Make sure the extended roll off is larger than default.
+        if sigma < defaultSigma
+            sigma = defaultSigma;
+        end
+    else  % classic gaussian roll
+        sigma = OPTION.lowpassRoll;
+    end
+
+    if flg.highpass
+        obj.bandpass = (radius < lowpassCut) .* obj.bandpass + ...
+                   (radius >= lowpassCut) .* gaussian(radius, lowpassCut, sigma);
+    else
+        obj.bandpass = (radius < lowpassCut) + ...
+                   (radius >= lowpassCut) .* gaussian(radius, lowpassCut, sigma);
+    end
+end
+
+end  % setBandpass
+
+
+function [OPTION, flg] = checkIN(PIXEL, HIGHPASS, LOWPASS, OPTION, defaultSigma)
+
+% PIXEL
+if ~isscalar(PIXEL) || ~isnumeric(PIXEL) || isinf(PIXEL) || ~(PIXEL > 0)
+    error('EMC:PIXEL', 'PIXEL should be a positive float|int')
+end
+
+OPTION = EMC_getOption(OPTION, {'highpassRoll', 'highpassThresh', ...
+                                'lowpassRoll', 'lowpassThresh'}, false);
+
+% HIGHPASS cutoff
+if ~isscalar(HIGHPASS)
+    error('EMC:HIGHPASS', 'HIGHPASS should be a scalar, got a %s of size %s', ...
+          class(HIGHPASS), mat2str(size(HIGHPASS)))
+elseif isnan(HIGHPASS) || HIGHPASS == 0
+    flg.highpass = false;
+elseif isnumeric(HIGHPASS) && ~isinf(HIGHPASS) && HIGHPASS > 0
+    if HIGHPASS < PIXEL * 2
+        error('EMC:HIGHPASS', ...
+              'HIGHPASS should be greater (lower resolution) or equal to Nyquist (%.3f)', PIXEL * 2)
+    end
+    flg.highpass = true;
+else
+    error('EMC:HIGHPASS', 'HIGHPASS should be a positive float|int or nan')
+end
+
+% LOWPASS cutoff
+if isscalar(LOWPASS) && isnumeric(LOWPASS) && ~isinf(LOWPASS)
+    if isnan(LOWPASS) || LOWPASS == 0
+        flg.highpass = false;
+    elseif LOWPASS < PIXEL * 2
+        error('EMC:LOWPASS', 'LOWPASS should be greater (lower resolution) or equal to Nyquist (%.3f)', ...
+              PIXEL * 2)
+    elseif flg.highpass && HIGHPASS < LOWPASS
+        error('EMC:LOWPASS', 'LOWPASS should be smaller (high frequency) than HIGHPASS')
+    end
+    flg.lowpass = true;
+elseif strcmpi(LOWPASS, 'nyquist')
+    flg.lowpass = true;
+else
+    error('EMC:LOWPASS', "LOWPASS should be a non negative float|int, nan or 'nyquist'")
+end
+
+% highpassRoll
+if isfield(OPTION, 'highpassRoll')
+    if ~(isscalar(OPTION.highpassRoll) && isnumeric(OPTION.highpassRoll) ...
+         && OPTION.highpassRoll >= 0 && ~isinf(OPTION.highpassRoll)) ...
+       && ...
+       ~((isstring(OPTION.highpassRoll) || ischar(OPTION.highpassRoll)) && ...
+         strcmpi(OPTION.highpassRoll, 'extended'))
+        error('EMC:highpassRoll', "OPTION.highpassRoll should be a positive float|int or 'extended'")
+    end
+else
+    OPTION.highpassRoll = defaultSigma;  % default
+end
+
+% highpassThresh
+if isfield(OPTION, 'highpassThresh')
+    if ~isscalar(OPTION.highpassThresh) && ~isnumeric(OPTION.highpassThresh)
+        error('EMC:highpassThresh', 'OPTION.highpassThresh should be a float|int, got %s of size %s', ...
+              class(OPTION.highpassThresh), mat2str(size(OPTION.highpassThresh)))
+    elseif OPTION.highpassThresh < 0 || OPTION.highpassThresh >= 1 || isnan(OPTION.highpassThresh)
+        error('EMC:highpassThresh', 'OPTION.highpassThresh should be between 0 and 1, got %.3f', ...
+              OPTION.highpassThresh)
+    end
+else
+    OPTION.highpassThresh = 1e-3;  % default
+end
+
+% lowpassRoll
+if isfield(OPTION, 'lowpassRoll')
+    if ~(isscalar(OPTION.lowpassRoll) && isnumeric(OPTION.lowpassRoll) ...
+         && OPTION.lowpassRoll >= 0 && ~isinf(OPTION.lowpassRoll)) ...
+       && ...
+       ~((isstring(OPTION.lowpassRoll) || ischar(OPTION.lowpassRoll)) && ...
+         strcmpi(OPTION.lowpassRoll, 'extended'))
+        error('EMC:lowpassRoll', "OPTION.lowpassRoll should be a positive float|int or 'extended'")
+    end
+else
+    OPTION.lowpassRoll = defaultSigma;  % default
+end
+
+% lowpassThresh
+if isfield(OPTION, 'lowpassThresh')
+    if ~isscalar(OPTION.lowpassThresh) && ~isnumeric(OPTION.lowpassThresh)
+        error('EMC:lowpassThresh', 'OPTION.lowpassThresh should be a float|int, got %s of size %s', ...
+              class(OPTION.lowpassThresh), mat2str(size(OPTION.lowpassThresh)))
+    elseif OPTION.lowpassThresh < 0 || OPTION.lowpassThresh >= 1 || isnan(OPTION.lowpassThresh)
+        error('EMC:lowpassThresh', 'OPTION.lowpassThresh should be between 0 and 1, got %.3f', ...
+              OPTION.lowpassThresh)
+    end
+else
+    OPTION.lowpassThresh = 1e-3;  % default
+end
+
+end  % checkIN

--- a/transformations/@EMC_Fourier/standardize.m
+++ b/transformations/@EMC_Fourier/standardize.m
@@ -1,0 +1,33 @@
+function DFT = standardize(obj, DFT)
+%
+% DFT = obj.standardize(DFT)
+% Set the real space mean to ~0 and real space variance to ~1 of the ARRAY.
+% The mean and variance are changed in frequency space.
+%
+% Input:
+%   DFT (numeric):  2d/3d Discrete Fourier Transform.
+%
+% Output:
+%   DFT (numeric):  Standardize DFT.
+%
+
+if ~obj.half
+    DFT(1) = 0;
+   	DFT = DFT ./ (sqrt(sum(abs(DFT).^2, 'all')) / numel(DFT));
+if obj.half
+    % Capture every independant chunk (same for 2d or 3d)
+    if obj.centered
+        error('not finished')
+        
+    else
+        DFT(1) = 0;
+        cD = ceil(obj.size_real(1)/2);  % center of donor
+        factor = sum(abs(DFT(1,:,:)).^2, 'all');  % unique row/plane
+        factor = factor + 2*sum(abs(DFT(2:cD,:,:)).^2, 'all');  % common chunk
+        if obj.isEven(1); factor = factor + sum(abs(DFT(cD+1,:,:)).^2, 'all'); end  % unique row/plane
+    end
+
+  	DFT = DFT ./ (sqrt(factor) / prod(obj.size_real, 'native'));
+end
+
+end

--- a/transformations/@EMC_Fourier/to.m
+++ b/transformations/@EMC_Fourier/to.m
@@ -1,0 +1,45 @@
+function obj = to(obj, STR)
+%
+% obj = obj.to(STR)
+% Change the precision or the method.
+%
+% Input:
+%   STR (str|char): If 'single' or 'double': cast obj properties to the desired precision.
+%                   If 'cpu' or 'gpu': push obj properties to the desired device/host.
+%
+% Output:
+%   obj (handle):   EMC_Fourier instance.
+%
+
+
+if strcmpi(STR, 'cpu')
+    if ~strcmpi(obj.method, 'cpu')
+       obj.method = 'cpu';
+       obj.isOnGpu = false;
+       if ~isemtpy(obj.bandpass); obj.bandpass        = gpuArray(obj.bandpass);        end
+       if index_fftshift_isSet;   obj.index_fftshift  = gpuArray(obj.index_fftshift);  end
+       if index_ifftshift_isSet;  obj.index_ifftshift = gpuArray(obj.index_ifftshift); end
+       if index_half2full_isSet;  obj.index_half2full = gpuArray(obj.index_half2full); end
+    end
+elseif strcmpi(STR, 'gpu')
+    if ~strcmpi(obj.method, 'gpu')
+       obj.method = 'gpu';
+       obj.isOnGpu = true;
+       if ~isemtpy(obj.bandpass); obj.bandpass        = gather(obj.bandpass);        end
+       if index_fftshift_isSet;   obj.index_fftshift  = gather(obj.index_fftshift);  end
+       if index_ifftshift_isSet;  obj.index_ifftshift = gather(obj.index_ifftshift); end
+       if index_half2full_isSet;  obj.index_half2full = gather(obj.index_half2full); end
+    end
+elseif strcmpi(STR, 'double')
+	if ~strcmpi(obj.precision, 'double')
+       obj.precision = 'double';
+       if ~isemtpy(obj.bandpass); obj.bandpass = EMC_setPrecision(obj.bandpass, 'double'); end
+	end
+elseif strcmpi(STR, 'single')
+	if ~strcmpi(obj.precision, 'single')
+       obj.precision = 'single';
+       if ~isemtpy(obj.bandpass); obj.bandpass = EMC_setPrecision(obj.bandpass, 'single'); end
+	end
+end
+
+end  % to


### PR DESCRIPTION
## EMC_maskReference:
1. *Lowpass filter*: As mentioned before, **EMC_maskReference** was applying an extended lowpassRoll with **fsc=true**, similar to what is applied with **fsc=false**. Now, **EMC_maskReference** follows **BH_mask3d** and applies the default lowpassRoll with **fsc=true**.
2. The mask used for the COM was not the correct one (if **fsc=true**). Now it is fixed and I renamed *currentMask* to *binaryMask* to make it clearer.
3. the dilation is fixed and gives exactly the same results as **BH_mask3d**

**EMC_maskReference** is *almost* giving exactly the same results as **BH_mask3d**. The only small difference comes from the lowpass filter (only with **fsc=true**) that has a larger roll-off with **EMC_getBandpass** than **BH_bandpass3d**. Using the lowpass filters from **BH_bandpass3d** gives exactly the same masks, which makes me think that is the only different between **EMC_maskReference** and **BH_bandpass3d**.

## EMC_centerOfMass:
At the end, I didn't add the MASK... If you want to use a mask, apply it to the input image directly?
Furthermore, I think in most cases, if not all, ```min(binaryVol(MASK > 0.01)) ``` (line 341 of  **BH_bandpass3d**) is equal to 0 with fscMask. With the example I tested, the COM is almost exactly the same as **BH_mask3d** and the only difference comes from the lowpass filter (when I use **BH_bandpass3d**, I have the exact same COM as **BH_mask3d**).